### PR TITLE
fix dirs

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -1,7 +1,0 @@
-name = 'Lora Keywords Finder'
-description = 'Extension to find trained keywords for a LoRA models from CivitAI API.'
-version = '0.0.5'
-author = 'Avaray'
-repository_url = 'https://github.com/Avaray/lora-keywords-finder'
-# website = 'https://dav.one/lora-keyword-picker'
-tags = ['prompt', 'trained', 'keyword', 'keywords', 'trigger', 'trigger word', 'words', 'find', 'finder']

--- a/scripts/lora_keywords_finder.py
+++ b/scripts/lora_keywords_finder.py
@@ -7,13 +7,13 @@ import gradio as gr  # type: ignore
 from modules import scripts
 from modules import shared
 
+known_dir = os.path.join(scripts.basedir(), "known")
+os.makedirs(known_dir, exist_ok=True)
+
 
 class LoraKeywordsFinder(scripts.Script):
     def __init__(self):
         super().__init__()
-        # Ensure the known directory exists
-        known_dir = os.path.join(scripts.basedir(), "extensions", "lora-keywords-finder", "known")
-        os.makedirs(known_dir, exist_ok=True)
 
     def title(self):
         return "LoRA Keywords Finder"
@@ -51,7 +51,7 @@ class LoraKeywordsFinder(scripts.Script):
             with gr.Row(variant="compact"):
                 # Add an empty choice as the default selection
                 choices = [""] + self.list_lora_files()
-                
+
                 lora_dropdown = gr.Dropdown(
                     show_label=False,
                     choices=choices,
@@ -123,7 +123,7 @@ class LoraKeywordsFinder(scripts.Script):
                     return text;
                 }
                 """
-                
+
                 # Event handler for dropdown change
                 lora_dropdown.change(
                     fn=self.get_trained_words,
@@ -197,7 +197,6 @@ class LoraKeywordsFinder(scripts.Script):
 
         print(f"Selected {lora_file}, file hash: {file_hash}")
 
-        known_dir = os.path.join(scripts.basedir(), "extensions", "lora-keywords-finder", "known")
         json_file_path = os.path.join(known_dir, f"{file_hash}.json")
 
         # Check if the JSON file exists

--- a/scripts/lora_keywords_finder.py
+++ b/scripts/lora_keywords_finder.py
@@ -3,9 +3,10 @@ import re
 import json
 import hashlib
 import requests
-import gradio as gr # type: ignore
+import gradio as gr  # type: ignore
 from modules import scripts
 from modules import shared
+
 
 class LoraKeywordsFinder(scripts.Script):
     def __init__(self):
@@ -150,7 +151,7 @@ class LoraKeywordsFinder(scripts.Script):
         return re.sub(r",(?=[^\s])", ", ", keyword).strip()
 
     def list_lora_files(self):
-        lora_dir = os.path.join(scripts.basedir(), "..", "..", "models", "Lora")
+        lora_dir = shared.cmd_opts.lora_dir
         root_files = []
         subdir_files = []
         
@@ -181,9 +182,8 @@ class LoraKeywordsFinder(scripts.Script):
         if not lora_file:
             return gr.update(value="")
 
-        lora_dir = os.path.join(scripts.basedir(), "..", "..", "models", "Lora")
         # Construct full path using os.path.join to handle subdirectories correctly
-        full_path = os.path.join(lora_dir, lora_file)
+        full_path = os.path.join(shared.cmd_opts.lora_dir, lora_file)
         
         try:
             with open(full_path, "rb") as f:

--- a/scripts/lora_keywords_finder.py
+++ b/scripts/lora_keywords_finder.py
@@ -158,7 +158,7 @@ class LoraKeywordsFinder(scripts.Script):
         # Walk through directory and subdirectories
         for root, _, files in os.walk(lora_dir):
             for filename in files:
-                if filename.endswith((".pt", ".safetensors")):
+                if filename.lower().endswith((".pt", ".safetensors")):
                     # Get the relative path from the lora_dir
                     rel_path = os.path.relpath(root, lora_dir)
                     if rel_path == ".":


### PR DESCRIPTION
### fixed issues

lora dir can be change by user to any dir using --lora-dir
or --data-dir when --lora-dir not in use

tldr: use `shared.cmd_opts.lora_dir` to get the dir and not a relative path you're using

https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Command-Line-Arguments-and-Settings

> it can also be in shared.cmd_opts.lyco_dir_backcompat 
but it didn't bother implemented in it

---

fix know_dir 
extension installation location can also change

### other improvements that you might want to implement

well this is not crucial generally speaking you should use the funcrions in webui/module/hashes.py to calculate the hashes of files, reason being that the results can be cached and reused

---

about the lora list drowdown choices
currently you scan the lora as webui launch the results will get saved in to gradio and reuse every time when the page loads or reloads, later on the page the user can manually refresh the list

what you may not have realized is that but you may not have realized is that the list that is scanned at the initial loading will not be refresh when the mentally refreshes
which means if you add som new lora after webui launches, manually rescan rescan (new lora appears on the list), refresh the webpage (new lora is gone)

one way to fix this is to rescan lora on every page load
you can do so by add add something like this, this will run on every page load
```py
    def ui(self, is_img2img):
        with gr.Blocks(analytics_enabled=False) as block:
                block.load(reload_lora_list, outputs=[lora_dropdown])
# this should be close enough but I did not test it
```